### PR TITLE
Update media-preview.js

### DIFF
--- a/xrextras/src/mediarecorder/media-preview.js
+++ b/xrextras/src/mediarecorder/media-preview.js
@@ -172,6 +172,9 @@ const initMediaPreview = (options = {}) => {
   const isWKWebViewiOS = ['Microsoft Edge', 'Google Chrome', 'Mozilla Firefox Focus', 'Opera Touch',
     'Pinterest', 'Snapchat', 'Instagram', 'Facebook', 'Facebook Messenger', 'Line', 'LinkedIn',
     'Naver', 'Baidu'].includes(window.XR8.XrDevice.deviceEstimate().browser.inAppBrowser) ||
+    ['Microsoft Edge', 'Google Chrome', 'Mozilla Firefox Focus', 'Opera Touch',
+      'Pinterest', 'Snapchat', 'Instagram', 'Facebook', 'Facebook Messenger', 'Line', 'LinkedIn',
+      'Naver', 'Baidu'].includes(window.XR8.XrDevice.deviceEstimate().browser.name) ||
     window.XR8.XrDevice.deviceEstimate().browser.name === 'Firefox'
 
   const tmpFile = new File([new Blob()], 'tmp.mp4', {


### PR DESCRIPTION
Currently web view check is done against the "inAppBrowser" value of the "browser" object. In iOS the value is not in "inAppBrowser" but in "name". So I added an OR to check it against both.