### PR TITLE
Expose hideLoadingScreen and hideLoadingScreenNow

### DIFF
--- a/xrextras/src/loadingmodule/loading-module.js
+++ b/xrextras/src/loadingmodule/loading-module.js
@@ -443,6 +443,8 @@ function create() {
   return {
     pipelineModule,
     showLoading,
+    hideLoadingScreen,
+    hideLoadingScreenNow,
     setAppLoadedProvider,
   }
 }


### PR DESCRIPTION
Expose `hideLoadingScreen` and `hideLoadingScreenNow` to consumers.

Since `showLoading` mutates DOM, consumers can call these methods to clean up side-effects or bail early from an 8thWall session. For instance if I am inside a SPA and the user decides to exit the 8thwall route before the loading has finished, I would call these methods to cleanup the loading DOM mutations.
