### PR TITLE
ThreeJS pipeline module: Setting camera aspect on canvas resize

### DIFF
--- a/examples/threejs/custom-pipeline-module/customThreejsPipelineModule.js
+++ b/examples/threejs/custom-pipeline-module/customThreejsPipelineModule.js
@@ -47,8 +47,10 @@ const customThreejsPipelineModule = () => {
       }
     },
     onCanvasSizeChange: ({canvasWidth, canvasHeight}) => {
-      const {renderer} = scene3
+      const {renderer, camera} = scene3
       renderer.setSize(canvasWidth, canvasHeight)
+      camera.aspect = canvasWidth / canvasHeight
+      camera.updateProjectionMatrix()
     },
     onRender: () => {
       const {scene, renderer, camera} = scene3


### PR DESCRIPTION
The threejs camera needs to update the aspect to match the canvas size. Currently, the aspect is only set during initialization, so if the canvas size changes, the scene will look stretched.

In my case, the canvas wasn't sized before `onStart` was called, so it assigned the aspect based on the default canvas size of 150x300.