### PR TITLE
dispatch events on recorder start, stop and error events

### DIFF
--- a/xrextras/src/mediarecorder/record-button.js
+++ b/xrextras/src/mediarecorder/record-button.js
@@ -115,8 +115,17 @@ const startRecording = () => {
       }
       window.dispatchEvent(new CustomEvent('mediarecorder-recordcomplete', {detail: result}))
     },
-    onStop: () => showLoading(),
-    onError: () => clearState(),
+    onStart: (result) => {
+      window.dispatchresultvresultnt(new CustomEvent('mediarecorder-recordstart', { detail: result }))
+    },
+    onStop: (result) => {
+      window.dispatchEvent(new CustomEvent('mediarecorder-recordstop', { detail: result }))
+      showLoading()
+    },
+    onError: (result) => {
+      window.dispatchEvent(new CustomEvent('mediarecorder-recordstop', { detail: result }))
+      clearState()
+    },
     onProcessFrame: ({elapsedTimeMs, maxRecordingMs, ctx}) => {
       const timeLeft = (1 - elapsedTimeMs / maxRecordingMs)
       progressBar.style.strokeDashoffset = `${100 * timeLeft}`

--- a/xrextras/src/mediarecorder/record-button.js
+++ b/xrextras/src/mediarecorder/record-button.js
@@ -116,14 +116,14 @@ const startRecording = () => {
       window.dispatchEvent(new CustomEvent('mediarecorder-recordcomplete', {detail: result}))
     },
     onStart: (result) => {
-      window.dispatchresultvresultnt(new CustomEvent('mediarecorder-recordstart', { detail: result }))
+      window.dispatchEvent(new CustomEvent('mediarecorder-recordstart', { detail: result }))
     },
     onStop: (result) => {
       window.dispatchEvent(new CustomEvent('mediarecorder-recordstop', { detail: result }))
       showLoading()
     },
     onError: (result) => {
-      window.dispatchEvent(new CustomEvent('mediarecorder-recordstop', { detail: result }))
+      window.dispatchEvent(new CustomEvent('mediarecorder-recorderror', { detail: result }))
       clearState()
     },
     onProcessFrame: ({elapsedTimeMs, maxRecordingMs, ctx}) => {


### PR DESCRIPTION
Currently, when users need to subscribe to a record start event, the only option is to find the dom element and add an event listener for `touchstart` event. This works fine in a vanilla JavaScript environment. But with SPA frameworks like Angular or React, it is hard to get hold of the recorder button as it gets added to the dom by Xtras library dynamically. 

Secondly, Xtras library is already dispatching events for several recorder events, not sure why we avoided events for `start`, `stop`, and `error`. 

https://www.8thwall.com/docs/web/#xr8mediarecorderrecordvideo