### PR TITLE
Update custom threejs renderer to support iOS 15.4

### DIFF
--- a/examples/threejs/custom-pipeline-module/README.md
+++ b/examples/threejs/custom-pipeline-module/README.md
@@ -49,9 +49,9 @@ index.js:
 ...
 ...
 
-const myThreejsModule = customThreejsPipelineModule()
-
 const onxrloaded = () => {
+  const myThreejsModule = customThreejsPipelineModule()
+
   XR8.addCameraPipelineModules([  // Add camera pipeline modules.
     XR8.GlTextureRenderer.pipelineModule(),      // Draws the camera feed.
     myThreejsModule, // Custom three.js pipeline module. Replaces XR8.Threejs.pipelineModule()

--- a/examples/threejs/custom-pipeline-module/customThreejsPipelineModule.js
+++ b/examples/threejs/custom-pipeline-module/customThreejsPipelineModule.js
@@ -27,6 +27,12 @@ const customThreejsPipelineModule = () => {
     scene3 = {scene, camera, renderer}
     engaged = true
   }
+
+  // This is a workaround for https://bugs.webkit.org/show_bug.cgi?id=237230
+  // Once the fix is released, we can add `&& parseFloat(device.osVersion) < 15.x`
+  const device = window.XR8.XrDevice.deviceEstimate()
+  const needsPrerenderFinish = device.os === 'iOS' && parseFloat(device.osVersion) >= 15.4
+
   return {
     name: 'customthreejs',
     onStart: (args) => engage(args),
@@ -77,6 +83,9 @@ const customThreejsPipelineModule = () => {
     onRender: () => {
       const {scene, renderer, camera} = scene3
       renderer.clearDepth()
+      if (needsPrerenderFinish) {
+        renderer.getContext().finish()
+      }
       renderer.render(scene, camera)
     },
     // Get a handle to the xr scene, camera and renderer. Returns:


### PR DESCRIPTION
## Context

Without this change, [this bug](https://bugs.webkit.org/show_bug.cgi?id=237113) can cause rendering issues. 

We need to delay the instantiation of the custom renderer until XR8 is loaded, now that we're using XR8.JsDevice.

## Testing

Taking the sample threejs project and using the custom renderer, the visual issues are observed, until the `finish` call is added, which fixes it.

