### PR TITLE
Add CanvasScreenshot to the pipeline modules for the RecordButton

### DIFF
--- a/xrextras/src/mediarecorder/record-button.js
+++ b/xrextras/src/mediarecorder/record-button.js
@@ -208,6 +208,7 @@ const up = () => {
 
 const initRecordButton = () => {
   window.XR8.addCameraPipelineModule(XR8.MediaRecorder.pipelineModule())
+  window.XR8.addCameraPipelineModule(XR8.CanvasScreenshot.pipelineModule())
 
   document.body.insertAdjacentHTML('beforeend', htmlContent)
 
@@ -232,6 +233,7 @@ const initRecordButton = () => {
 
 const removeRecordButton = () => {
   window.XR8.removeCameraPipelineModule(window.XR8.MediaRecorder.pipelineModule().name)
+  window.XR8.removeCameraPipelineModule(window.XR8.CanvasScreenshot.pipelineModule().name)
   container.parentNode.removeChild(container)
   flashElement.parentNode.removeChild(flashElement)
 


### PR DESCRIPTION
The photo mode (or standard photo) wasn't working without it.
It was returning `Error: Not attached to a running camera feed`