### PR TITLE
Handling videoPreview.oncanplaythrough() Event for iOS 17.4 Migration: A Proposed Contribution

### DIFF
--- a/xrextras/src/mediarecorder/media-preview.js
+++ b/xrextras/src/mediarecorder/media-preview.js
@@ -204,6 +204,9 @@ const showVideoPreview = ({videoBlob}) => {
     maybeFinishLoading()
   }
 
+  //ios 17.4 issue
+  videoPreview.oncanplaythrough()
+
   videoPreview.src = currentUrl
   videoPreview.load()
 }


### PR DESCRIPTION
After the Safari 17.4 update, due to browser policies, videos were recorded but could not advance past the preview screen. However, this issue was resolved by implementing videoPreview.oncanplaythrough().

