### PR TITLE
update playcanvas shader properties

### DIFF
--- a/xrextras/src/playcanvas/playcanvas.js
+++ b/xrextras/src/playcanvas/playcanvas.js
@@ -12,9 +12,9 @@ function create() {
   // Attach a shader to a material that makes it appear transparent while still receiving shadows.
   const makeShadowMaterial = ({pc, material}) => {
     const materialResource = material.resource || material
-    materialResource.chunks.APIVersion = pc.CHUNKAPI_1_62
+    materialResource.chunks.APIVersion = pc.CHUNKAPI_1_65
     materialResource.chunks.endPS = `
-      litShaderArgs.opacity = mix(light0_shadowIntensity, 0.0, shadow0);
+      litArgs_opacity = mix(light0_shadowIntensity, 0.0, shadow0);
       gl_FragColor.rgb = vec3(0.0);
     `
     materialResource.blendType = pc.BLEND_PREMULTIPLIED


### PR DESCRIPTION
> The shader properties for playcanvas have changed in latest engine update - if you could please update this function
this is the fix required below
```
xrcontroller.prototype.makeShadowMaterial = function({ pc, material }) {
  const n = material.resource || material
  n.chunks.APIVersion = pc.CHUNKAPI_1_65
  n.chunks.endPS = "\n      litArgs_opacity = mix(light0_shadowIntensity, 0.0, shadow0);\n      gl_FragColor.rgb = vec3(0.0);\n    "
  n.blendType = pc.BLEND_PREMULTIPLIED
  n.update()
}
```


https://forum.8thwall.com/t/playcanvas-shader-material-not-working-xrextras-playcanvas-makeshadowmaterial/2177